### PR TITLE
6 months worth of security patches!

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/ManagePermissionsActivity.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/ManagePermissionsActivity.java
@@ -35,6 +35,7 @@ import android.content.pm.PermissionInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.MenuItem;
 
@@ -119,6 +120,15 @@ public final class ManagePermissionsActivity extends SettingsActivity {
         // instance, re-use its Fragment instead of making a new one.
         if ((DeviceUtils.isTelevision(this) || DeviceUtils.isAuto(this)
                 || DeviceUtils.isWear(this)) && savedInstanceState != null) {
+            return;
+        }
+
+        boolean provisioned = Settings.Global.getInt(
+                getContentResolver(), Settings.Global.DEVICE_PROVISIONED, 0) != 0;
+        boolean completed = Settings.Secure.getInt(
+                getContentResolver(), Settings.Secure.USER_SETUP_COMPLETE, 0) != 0;
+        if (!provisioned || !completed) {
+            finishAfterTransition();
             return;
         }
 


### PR DESCRIPTION
RESTRICT AUTOMERGE Finish ManagePermissionsActivity if device is not provisioned

If the device isn't set up yet, do not allow access to the permissions settings

Bug: 253043490
Test: manual
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:5e297ab51388db5375093f7dc21d37bd59de827c) Merged-In: I6e8fb8f2d934cff965069493740cfc1c59c3623f Change-Id: I6e8fb8f2d934cff965069493740cfc1c59c3623f